### PR TITLE
Add NSG-subnet association

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,12 @@ resource "azurerm_network_security_group" "nsg" {
   }
 }
 
+# Create the NSG-subnet associaton
+resource "azurerm_subnet_network_security_group_association" "subnetnsg" {
+  subnet_id                 = azurerm_subnet.subnet.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
 # Create network interface
 resource "azurerm_network_interface" "nic" {
   name                = "${var.prefix}NIC"


### PR DESCRIPTION
This is just a detail really, but in this sample the NSG is not associated to anything and is thus not effective... I have added an association to the virtual network subnet so that the rules will apply to any NIC in that subnet.